### PR TITLE
Fixes RCE in OpenVPN params and Fixes issue #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,16 @@
 OpenVPNConnect is a WiFi Pineapple Module that allows you to connect to an openvpn server from the module interface
 
 ## Changelog:
- - Version 1.0.2: Added in current status when revisiting page, logging, and ability to install dependencies to SD card or local storage. Also squashed some bugs :)
- - Version 1.0.1: Minor Revisions, added Dynamic Gateway and the ability to use auth-user-pass. Unofficial Release (Github Only)
- - Version 1.0: Initial Release!
+ - Version 1.3: 
+    - Now with no RCEs :D...Fixed a major RCE caused by not sanitizing user input when passing in certain OpenVPN parameters.
+    - Added stability improvements for package management for those with fresh upgrades to 2.6.X WiFi Pineapple firmware.
+    - Lastly, revised the revision numbers to fall in line with the formal releases.
+ - Version 1.2: 
+    - Added in current status when revisiting page, logging, and ability to install dependencies to SD card or local storage. Also squashed some bugs :)
+ - Version 1.1: 
+    - Minor Revisions, added Dynamic Gateway and the ability to use auth-user-pass. Unofficial Release (Github Only)
+ - Version 1.0: 
+    - Initial Release!
 
 ## Screenshots:
 ![](https://raw.githubusercontent.com/3ndG4me/OpenVPNConnect/master/openvpnconnect_1.png)

--- a/api/module.php
+++ b/api/module.php
@@ -27,7 +27,7 @@ class OpenVPNConnect extends Module{
                 $this->initializeModule();
                 break;
             case 'handleDependencies':
-                $this->handleDependencies();
+                $this->handleDependencies(false);
                 break;
             case 'handleDependenciesSDCard':
                 $this->handleDependenciesSDCard();
@@ -103,7 +103,6 @@ class OpenVPNConnect extends Module{
 
     // Handles dependency installation and removal
     private function handleDependencies($sd){
-    
 
         if($this->checkDependency('openvpn')){
             $this->execBackground('opkg remove openvpn-openssl');
@@ -114,7 +113,6 @@ class OpenVPNConnect extends Module{
                 $this->execBackground('opkg install openvpn-openssl --dest sd');
                 $messsage = "Depedencies should now be installed! (Installed to SD card) Please wait for the page to refresh...";
             }else{
-                $this->execBackground('opkg update');
                 $this->installDependency('openvpn-openssl');
                 $messsage = "Depedencies should now be installed! (Installed to local storage) Please wait for the page to refresh...";
             }
@@ -122,7 +120,8 @@ class OpenVPNConnect extends Module{
         }
          
         $this->response = array("success" => true,
-                                "content" => $messsage);
+                                "content" => $messsage,
+                                "test" => $sd);
     }
 
     // Helper function to handle dependency installation and removal for sd card. Passes the SD flag to the real handleDependencies() function
@@ -189,7 +188,7 @@ class OpenVPNConnect extends Module{
 
 
         if($inputData[3] != ''){
-            $openvpn_flags = escapeshellcmd($inputData[3](=);
+            $openvpn_flags = escapeshellcmd($inputData[3]);
             $open_vpn_cmd .= $openvpn_flags;
         }
 

--- a/api/module.php
+++ b/api/module.php
@@ -114,6 +114,7 @@ class OpenVPNConnect extends Module{
                 $this->execBackground('opkg install openvpn-openssl --dest sd');
                 $messsage = "Depedencies should now be installed! (Installed to SD card) Please wait for the page to refresh...";
             }else{
+                $this->execBackground('opkg update');
                 $this->installDependency('openvpn-openssl');
                 $messsage = "Depedencies should now be installed! (Installed to local storage) Please wait for the page to refresh...";
             }
@@ -121,8 +122,7 @@ class OpenVPNConnect extends Module{
         }
          
         $this->response = array("success" => true,
-                                "content" => $messsage,
-                                "test" => $sd);
+                                "content" => $messsage);
     }
 
     // Helper function to handle dependency installation and removal for sd card. Passes the SD flag to the real handleDependencies() function
@@ -190,7 +190,8 @@ class OpenVPNConnect extends Module{
 
         if($inputData[3] != ''){
             $openvpn_flags = $inputData[3];
-            $open_vpn_cmd .= $openvpn_flags;
+            $open_vpn_cmd .= escapeshellcmd($openvpn_flags);
+            $this->execBackground("echo '" . $open_vpn_cmd . "' > /pineapple/modules/OpenVPNConnect/log/bug.txt");
         }
 
         

--- a/api/module.php
+++ b/api/module.php
@@ -158,7 +158,7 @@ class OpenVPNConnect extends Module{
         $open_vpn_cmd = "openvpn --log /pineapple/modules/OpenVPNConnect/log/vpn.log --status /pineapple/modules/OpenVPNConnect/log/status.log --config ";
         
         if($inputData[0] != ''){
-            $config_name = $inputData[0];
+            $config_name = escapeshellcmd($inputData[0]);
             $open_vpn_cmd .= "/root/vpn_config/" . $config_name . " ";
         }else{
             $this->response = array("success" => false,
@@ -189,9 +189,8 @@ class OpenVPNConnect extends Module{
 
 
         if($inputData[3] != ''){
-            $openvpn_flags = $inputData[3];
-            $open_vpn_cmd .= escapeshellcmd($openvpn_flags);
-            $this->execBackground("echo '" . $open_vpn_cmd . "' > /pineapple/modules/OpenVPNConnect/log/bug.txt");
+            $openvpn_flags = escapeshellcmd($inputData[3](=);
+            $open_vpn_cmd .= $openvpn_flags;
         }
 
         

--- a/injection-status.json
+++ b/injection-status.json
@@ -1,11 +1,11 @@
 {   
     "name": "OpenVPNConnect",
-    "version": "1.0.2",
+    "version": "1.3",
     "platform": "plugin",
     "progress": "100%",
     "state": "done",   
     "released": true,
-    "release_version": "1.0.2",
+    "release_version": "1.2",
     "download_url": "https://github.com/hak5/wifipineapple-modules/tree/master/OpenVPNConnect",
     "featured": false,
     "featured_image": ""

--- a/js/module.js
+++ b/js/module.js
@@ -43,7 +43,7 @@ registerController('openVPNConnectController', ['$api', '$scope', '$timeout', '$
 
                 $timeout(function() {$window.location.reload();}, 5000);
             }
-            //console.log(response) //Log the response to the console, this is useful for debugging.
+           //console.log(response) //Log the response to the console, this is useful for debugging.
         });
 
     }

--- a/module.html
+++ b/module.html
@@ -146,11 +146,10 @@
 												<b>1.3 </b>
 											</li>
 											<ul>
-												<li class="text-muted">Fixed a major RCE caused by not sanitizing user input when passing in custom OpenVPN parameters.</li>
+												<li class="text-muted">Now with no RCEs :D...Fixed a major RCE caused by not sanitizing user input when passing in custom OpenVPN parameters.</li>
                                                 <li class="text-muted">Added stability improvements for package management for those with fresh upgrades to 2.6.X WiFi Pineapple firmware.</li>
                                                 <li class="text-muted">Lastly, revised the revision numbers to fall in line with the formal releases.</li>
 											</ul>
-                                            <ul>
 											<li>
 												<b>1.2 </b>
 											</li>

--- a/module.html
+++ b/module.html
@@ -146,7 +146,7 @@
 												<b>1.3 </b>
 											</li>
 											<ul>
-												<li class="text-muted">Now with no RCEs :D...Fixed a major RCE caused by not sanitizing user input when passing in custom OpenVPN parameters.</li>
+												<li class="text-muted">Now with no RCEs :D...Fixed a major RCE caused by not sanitizing user input when passing in certain OpenVPN parameters.</li>
                                                 <li class="text-muted">Added stability improvements for package management for those with fresh upgrades to 2.6.X WiFi Pineapple firmware.</li>
                                                 <li class="text-muted">Lastly, revised the revision numbers to fall in line with the formal releases.</li>
 											</ul>

--- a/module.html
+++ b/module.html
@@ -141,15 +141,24 @@
 								</div>
 								<div id="collapseChangelog" class="panel-collapse collapse">
 									<div class="panel-body">
-										<ul>
+											<ul>
 											<li>
-												<b>1.0.2 </b>
+												<b>1.3 </b>
+											</li>
+											<ul>
+												<li class="text-muted">Fixed a major RCE caused by not sanitizing user input when passing in custom OpenVPN parameters.</li>
+                                                <li class="text-muted">Added stability improvements for package management for those with fresh upgrades to 2.6.X WiFi Pineapple firmware.</li>
+                                                <li class="text-muted">Lastly, revised the revision numbers to fall in line with the formal releases.</li>
+											</ul>
+                                            <ul>
+											<li>
+												<b>1.2 </b>
 											</li>
 											<ul>
 												<li class="text-muted">Added in current status when revisiting page, logging, and ability to install dependencies to SD card or local storage. Also squashed some bugs :)</li>
 											</ul>
 											<li>
-												<b>1.0.1 </b>
+												<b>1.1 </b>
 											</li>
 											<ul>
 												<li class="text-muted">Minor Revisions: Added better iptables management with dynamic gateway and the ability to use auth-user-pass. Unofficial Release (Github Only)</li>

--- a/module.info
+++ b/module.info
@@ -6,5 +6,5 @@
         "tetra"
     ],
     "title": "OpenVPNConnect",
-    "version": "1.0.2"
+    "version": "1.3"
 }


### PR DESCRIPTION
An RCE existed due improperly sanitized parameters in the config name and optional flags parameter. While it is true that once you are logged into a wifi pineapple, you should technically already have the root password, this was not intended functionality and is a vulnerability that should not exist.

Additionally, upstream improvements to firmware 2.6.x were made that resolve Issue #12 but unfortunately a bug was introduced at some point that caused dependency installation and handling to result in a 500 error response. This showed its face in the latest firmware release and was resolved by properly passing a default "false" parameter to the appropriate API function for handling dependencies.